### PR TITLE
Add support for multipart requests

### DIFF
--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyNetworkTrafficLogger.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyNetworkTrafficLogger.kt
@@ -65,7 +65,7 @@ internal class InspektifyNetworkTrafficLogger(private val logger: SystemLogger =
     private fun headersToLog(headers: Set<Map.Entry<String, List<String>>>?): String {
         headers ?: return ""
 
-        return headers.joinToString { (headerName, headerValues) ->
+        return headers.joinToString(separator = "") { (headerName, headerValues) ->
             "$tag $headerName:$headerValues\n"
         }
     }

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyRequestHandler.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyRequestHandler.kt
@@ -1,17 +1,25 @@
 package sp.bvantur.inspektify.ktor.client.data
 
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.utils.EmptyContent.contentLength
 import io.ktor.http.charset
 import io.ktor.http.content.OutgoingContent
 import io.ktor.util.AttributeKey
+import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.toByteArray
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import sp.bvantur.inspektify.ktor.KtorUtils
 import sp.bvantur.inspektify.ktor.client.data.utils.tryReadText
 import sp.bvantur.inspektify.ktor.client.domain.model.NetworkTraffic
 import sp.bvantur.inspektify.ktor.core.data.utils.NetworkTrafficDataUtils
 import sp.bvantur.inspektify.ktor.core.data.utils.NetworkTrafficDataUtils.redactHeaders
 import sp.bvantur.inspektify.ktor.core.data.utils.NetworkTrafficDataUtils.redactJsonProperties
+import sp.bvantur.inspektify.ktor.core.di.AppComponents
 
 internal class InspektifyRequestHandler {
     private val networkTrafficIdKey = AttributeKey<Long>("NetworkTrafficIdKey")
@@ -61,15 +69,75 @@ internal class InspektifyRequestHandler {
                 KtorUtils.channelToByteArray(content.readFrom())
             }
 
+            is MultiPartFormDataContent -> {
+                onGetMultipartByteArray(content)
+            }
+
             else -> {
                 null
             }
         }
 
         if (bytes != null) {
-            return ByteReadChannel(bytes).tryReadText(charset = charset) to (content.contentLength ?: 0L)
+            if (content !is MultiPartFormDataContent) {
+                return ByteReadChannel(bytes).tryReadText(charset = charset) to (content.contentLength ?: 0L)
+            }
+
+            val boundary = content.contentType.parameter("boundary")
+            if (boundary != null) {
+                try {
+                    val rawBodyString = ByteReadChannel(bytes).tryReadText(charset = charset) ?: ""
+                    val parts = rawBodyString.split("--$boundary")
+                        .drop(1)
+                        .dropLast(1)
+                    return prettifyMultipartJson(parts.joinToString("\n\n")) to bytes.size.toLong()
+                } catch (ignore: Exception) {
+                    println("Error parsing MultiPartFormDataContent parts: ${ignore.message}")
+                    return ByteReadChannel(bytes).tryReadText(charset = charset) to contentLength
+                }
+            }
         }
 
         return "" to 0L
+    }
+
+    private suspend fun onGetMultipartByteArray(content: MultiPartFormDataContent): ByteArray? {
+        val channel = ByteChannel(autoFlush = true)
+        try {
+            coroutineScope {
+                launch {
+                    content.writeTo(channel)
+                    channel.close()
+                }
+            }
+            return channel.toByteArray()
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (ignore: Exception) {
+            println("Error reading MultiPartFormDataContent: ${ignore.message}")
+            return null
+        } finally {
+            if (!channel.isClosedForWrite) channel.close()
+            if (!channel.isClosedForRead) channel.cancel(CancellationException("Closing temporary channel"))
+        }
+    }
+
+    private fun prettifyMultipartJson(input: String): String {
+        val jsonRegex = Regex("""\{[^}]*\}""")
+
+        return jsonRegex.replace(input) { match ->
+            try {
+                val jsonString = match.value
+
+                val json = AppComponents.getAppModule().json
+                val jsonElement = json.parseToJsonElement(jsonString)
+                val formattedJson = json.encodeToString(jsonElement)
+
+                formattedJson
+            } catch (ignore: Exception) {
+                println("Error prettifying Multipart json: ${ignore.message}")
+                match.value
+            }
+        }
     }
 }

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/NetworkTrafficDataUtils.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/NetworkTrafficDataUtils.kt
@@ -22,9 +22,13 @@ internal object NetworkTrafficDataUtils {
     fun String.redactJsonProperties(propertiesToRedact: List<String>): String {
         if (this.isEmpty()) return ""
 
-        val jsonElement = Json.parseToJsonElement(this)
-        val redactedElement = redactProperties(jsonElement, propertiesToRedact)
-        return Json.encodeToString(redactedElement)
+        try {
+            val jsonElement = Json.parseToJsonElement(this)
+            val redactedElement = redactProperties(jsonElement, propertiesToRedact)
+            return Json.encodeToString(redactedElement)
+        } catch (_: Exception) {
+            return this
+        }
     }
 
     private fun redactProperties(element: JsonElement, propertiesToRedact: List<String>): JsonElement = when (element) {


### PR DESCRIPTION
Added support for parsing multipart requests with Inspektify. The content is parsed like it is presented in the next screenshot:
<img src="https://github.com/user-attachments/assets/b52d5bc5-31a6-49e2-86b4-fb15908fdbc3" width="450">