### PR TITLE
Rework shake detection to reduce false positives

### DIFF
--- a/inspektify/src/androidMain/kotlin/sp/bvantur/inspektify/ktor/ShakeGestureListener.kt
+++ b/inspektify/src/androidMain/kotlin/sp/bvantur/inspektify/ktor/ShakeGestureListener.kt
@@ -5,6 +5,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.os.SystemClock
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import sp.bvantur.inspektify.ktor.client.shared.startInspektifyWindow
@@ -12,53 +13,54 @@ import kotlin.math.sqrt
 
 internal class ShakeGestureListener : DefaultLifecycleObserver {
 
-    private var sensorManager: SensorManager? = applicationContext.getSystemService(
+    private val sensorManager: SensorManager? = applicationContext.getSystemService(
         Context.SENSOR_SERVICE
     ) as? SensorManager
-    private var activeAcceleration = 10f
-    private var currentAcceleration = 0f
-    private var lastAcceleration = 0f
-    private val thresholdForAcceleration = 12f
+
+    private var overThresholdSamples = 0
+    private var lastTriggerAt = 0L
 
     private val sensorListener: SensorEventListener = object : SensorEventListener {
         override fun onSensorChanged(event: SensorEvent) {
             if (InspektifyActivity.inspektifyActivityInstance != null) return
 
-            val xCoordinate = event.values[0]
-            val yCoordinate = event.values[1]
-            val zCoordinate = event.values[2]
-            lastAcceleration = currentAcceleration
+            val now = SystemClock.elapsedRealtime()
+            if (now - lastTriggerAt < COOLDOWN_MS) return
 
-            currentAcceleration = sqrt(
-                xCoordinate * xCoordinate +
-                    yCoordinate * yCoordinate +
-                    zCoordinate * zCoordinate
+            val magnitude = sqrt(
+                event.values[0] * event.values[0] +
+                    event.values[1] * event.values[1] +
+                    event.values[2] * event.values[2]
             )
-            val delta = currentAcceleration - lastAcceleration
-            activeAcceleration = activeAcceleration * 0.9f + delta
 
-            if (activeAcceleration > thresholdForAcceleration) {
-                startInspektifyWindow()
+            if (magnitude > SHAKE_THRESHOLD) {
+                overThresholdSamples++
+                if (overThresholdSamples >= REQUIRED_CONSECUTIVE_SAMPLES) {
+                    lastTriggerAt = now
+                    overThresholdSamples = 0
+                    startInspektifyWindow()
+                }
+            } else {
+                overThresholdSamples = 0
             }
         }
 
         override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {}
     }
 
-    init {
-        currentAcceleration = SensorManager.GRAVITY_EARTH
-        lastAcceleration = SensorManager.GRAVITY_EARTH
-    }
-
     override fun onResume(owner: LifecycleOwner) {
-        sensorManager?.registerListener(
-            sensorListener,
-            sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
-            SensorManager.SENSOR_DELAY_NORMAL
-        )
+        val sensor = sensorManager?.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION) ?: return
+        sensorManager.registerListener(sensorListener, sensor, SensorManager.SENSOR_DELAY_GAME)
     }
 
     override fun onPause(owner: LifecycleOwner) {
         sensorManager?.unregisterListener(sensorListener)
+        overThresholdSamples = 0
+    }
+
+    private companion object {
+        const val SHAKE_THRESHOLD = 12f
+        const val REQUIRED_CONSECUTIVE_SAMPLES = 3
+        const val COOLDOWN_MS = 1000L
     }
 }


### PR DESCRIPTION
Replace the accelerometer-plus-IIR-filter approach with linear acceleration, a 3-consecutive-samples debounce, and a 1000 ms cooldown. Raw accelerometer readings included gravity, so tilts and gentle impacts (like placing the device on a table) could push the filtered value past the threshold and open Inspektify unintentionally. Linear acceleration reports movement with gravity removed, so at rest the magnitude is ~0 and only actual motion contributes; the debounce and cooldown then eliminate single-sample spikes and rapid retriggers. SENSOR_DELAY_GAME gives finer resolution so the 3-sample window corresponds to natural shake motion rather than a slow poll.