### PR TITLE
Add request tags to tell same-endpoint traffic apart

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Network transactions from previous sessions have a background in light gray colo
 7. [Ignore endpoints configuration](docs/IGNORE_ENDPOINTS_CONFIGURATION.md)
 8. [Payload too large policy](docs/PAYLOAD_TOO_LARGE_POLICY.md)
 9. [Extensions](docs/EXTENSIONS.md)
+10. [Request tags](docs/REQUEST_TAGS.md)
 
 ## Sample project
 

--- a/docs/REQUEST_TAGS.md
+++ b/docs/REQUEST_TAGS.md
@@ -1,0 +1,61 @@
+# Request tags
+
+Some APIs put every operation behind a single URL. A GraphQL endpoint is the common case: every
+query and mutation is a `POST` to `/graphql`, so the Inspektify list ends up as a wall of identical
+rows and the only way to tell them apart is to open each one and read the payload.
+
+`inspektifyTags` attaches one or more short names to a request, shown under it in the list:
+
+```
+client.post("https://www.example.com/graphql") {
+    inspektifyTags("SearchProducts", "query")
+    contentType(ContentType.Application.Json)
+    setBody(query)
+}
+```
+
+Tags are:
+
+- shown under the method and path on the list row
+- matched by the list search, and offered as search suggestions
+- listed in the transaction overview and in the copied/shared transaction text
+
+Requests without tags are displayed exactly as before.
+
+## Accumulating tags
+
+Repeated calls add to what is already there, so a client can tag everything it sends and individual
+call sites can narrow it down:
+
+```
+HttpClient {
+    defaultRequest { inspektifyTags("api-v2") }
+    install(InspektifyKtor)
+}
+
+// ...
+
+client.get("products") { inspektifyTags("SearchProducts") } // tagged "api-v2" and "SearchProducts"
+```
+
+Blank tags are dropped and duplicates collapsed, keeping the order they were added in.
+
+## Tagging in one place
+
+Rather than calling `inspektifyTags` at each call site, set it once wherever your requests are
+built. If every call already goes through a helper, that is a single line:
+
+```
+suspend fun callApi(operation: String, body: String): HttpResponse =
+    client.post("https://www.example.com/graphql") {
+        inspektifyTags(operation)
+        contentType(ContentType.Application.Json)
+        setBody(body)
+    }
+```
+
+If you build the plugin into debug builds only (see
+[Excluding Inspektify from Release Builds](EXCLUDING_INSPEKTIFY_FROM_RELEASE_BUILDS.md)), note that
+`inspektifyTags` lives in the Inspektify artifact, so a call site that always runs needs Inspektify
+on the release classpath too. Keep the call behind the same source set or flag that installs the
+plugin.

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/InspektifyTags.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/InspektifyTags.kt
@@ -1,0 +1,43 @@
+package sp.bvantur.inspektify.ktor
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.util.AttributeKey
+
+internal val InspektifyTagsAttributeKey: AttributeKey<List<String>> = AttributeKey("InspektifyTags")
+
+/**
+ * Tags this request with one or more short names, shown alongside it in the Inspektify list.
+ *
+ * Useful whenever the URL alone doesn't say much about a request — a GraphQL endpoint that serves
+ * every operation, a generic RPC path, or a batching endpoint:
+ *
+ * ```
+ * client.post("https://example.com/graphql") {
+ *     inspektifyTags("SearchProducts", "query")
+ *     setBody(query)
+ * }
+ * ```
+ *
+ * Tags are shown under the request on the list row, are matched by the list search, are offered as
+ * search suggestions, and are listed in the transaction overview. Requests without tags are
+ * unchanged.
+ *
+ * Calls accumulate, so a client can tag everything it sends and a call site can add to that:
+ *
+ * ```
+ * defaultRequest { inspektifyTags("api-v2") }
+ * // ...
+ * client.get("products") { inspektifyTags("SearchProducts") } // tagged "api-v2" and "SearchProducts"
+ * ```
+ *
+ * Blank tags are dropped and duplicates collapsed, keeping the order they were added in.
+ */
+public fun HttpRequestBuilder.inspektifyTags(vararg tags: String) {
+    val combined = (attributes.getOrNull(InspektifyTagsAttributeKey).orEmpty() + tags)
+        .filter { it.isNotBlank() }
+        .distinct()
+
+    if (combined.isNotEmpty()) {
+        attributes.put(InspektifyTagsAttributeKey, combined)
+    }
+}

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyRequestHandler.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyRequestHandler.kt
@@ -14,6 +14,7 @@ import io.ktor.utils.io.close
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import sp.bvantur.inspektify.ktor.InspektifyTagsAttributeKey
 import sp.bvantur.inspektify.ktor.KtorUtils
 import sp.bvantur.inspektify.ktor.PayloadTooLargePolicy
 import sp.bvantur.inspektify.ktor.client.data.utils.tryReadText
@@ -52,6 +53,7 @@ internal class InspektifyRequestHandler {
             host = url.host,
             path = url.pathSegments.joinToString("/"),
             protocol = url.protocol.name,
+            tags = request.attributes.getOrNull(InspektifyTagsAttributeKey),
             requestTimestamp = id,
             requestHeaders = headers.entries().redactHeaders(redactHeaders),
             requestPayload = payload?.redactJsonProperties(redactBodyProperties)

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/datasource/NetworkTrafficLocalDataSource.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/data/datasource/NetworkTrafficLocalDataSource.kt
@@ -18,6 +18,7 @@ internal class NetworkTrafficLocalDataSource {
                     host = networkTraffic.host,
                     path = networkTraffic.path,
                     protocol = networkTraffic.protocol,
+                    tags = networkTraffic.tags,
                     requestTimestamp = networkTraffic.requestTimestamp,
                     requestHeaders = networkTraffic.requestHeaders,
                     requestPayload = networkTraffic.requestPayload,

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/domain/model/NetworkTraffic.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/client/domain/model/NetworkTraffic.kt
@@ -8,6 +8,7 @@ internal data class NetworkTraffic(
     val host: String? = null,
     val path: String? = null,
     val protocol: String? = null,
+    val tags: List<String>? = null,
     val requestContentType: String? = null,
     val requestTimestamp: Long? = null,
     val requestHeaders: Set<Map.Entry<String, List<String>>>? = null,

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataExtensions.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataExtensions.kt
@@ -11,6 +11,7 @@ internal fun NetworkTrafficDataLocal.toNetworkTraffic(): NetworkTraffic = Networ
     host = host,
     path = path,
     protocol = protocol,
+    tags = tags,
     requestTimestamp = requestTimestamp,
     requestHeaders = requestHeaders,
     requestPayload = requestPayload,

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataLocalExtensions.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataLocalExtensions.kt
@@ -40,6 +40,8 @@ internal fun NetworkTrafficDataLocal.getMethodWithPath(): String {
     return "$method $path"
 }
 
+internal fun NetworkTrafficDataLocal.getTags(): List<String> = tags?.filter { it.isNotBlank() }.orEmpty()
+
 internal fun NetworkTrafficDataLocal.getHost(): String = host ?: ""
 
 internal fun NetworkTrafficDataLocal.getMethod(): String = method ?: ""

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/di/AppComponents.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/core/di/AppComponents.kt
@@ -57,7 +57,8 @@ internal object AppComponents {
             driver = DatabaseDriverProvider.createDriver(),
             NetworkTrafficDataLocalAdapter = NetworkTrafficDataLocal.Adapter(
                 responseHeadersAdapter = listOfNetworkTrafficHeaderAdapter,
-                requestHeadersAdapter = listOfNetworkTrafficHeaderAdapter
+                requestHeadersAdapter = listOfNetworkTrafficHeaderAdapter,
+                tagsAdapter = tagsAdapter
             )
         )
     }
@@ -72,4 +73,10 @@ internal object AppComponents {
 
             override fun encode(value: Set<Map.Entry<String, List<String>>>): String = json.encodeToString(value)
         }
+
+    private val tagsAdapter = object : ColumnAdapter<List<String>, String> {
+        override fun decode(databaseValue: String): List<String> = json.decodeFromString(databaseValue)
+
+        override fun encode(value: List<String>): String = json.encodeToString(value)
+    }
 }

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/details/data/mapper/OverviewNetworkTrafficMapper.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/details/data/mapper/OverviewNetworkTrafficMapper.kt
@@ -1,6 +1,7 @@
 package sp.bvantur.inspektify.ktor.details.data.mapper
 
 import sp.bvantur.inspektify.NetworkTrafficDataLocal
+import sp.bvantur.inspektify.ktor.core.data.utils.extensions.getTags
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.nullIfEmpty
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.nullToEmpty
 import sp.bvantur.inspektify.ktor.core.domain.utils.ByteSizeUtils
@@ -12,6 +13,9 @@ internal object OverviewNetworkTrafficMapper {
     fun getOverviewDataAsString(networkTrafficData: NetworkTrafficDataLocal): String {
         var overviewData = ""
         overviewData += "OVERVIEW:\n"
+        networkTrafficData.getTags().takeIf { it.isNotEmpty() }?.let {
+            overviewData += "Tags: ${it.joinToString()}\n"
+        }
         networkTrafficData.method?.let {
             overviewData += "Method: $it\n"
         }
@@ -42,6 +46,7 @@ internal object OverviewNetworkTrafficMapper {
     }
 
     fun toOverviewDomain(data: NetworkTrafficDataLocal): KtorOverviewData = KtorOverviewData(
+        tags = data.getTags().takeIf { it.isNotEmpty() }?.joinToString(),
         url = data.url,
         method = data.method,
         protocol = data.protocol,

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/details/domain/model/KtorOverviewData.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/details/domain/model/KtorOverviewData.kt
@@ -1,6 +1,7 @@
 package sp.bvantur.inspektify.ktor.details.domain.model
 
 internal data class KtorOverviewData(
+    val tags: String?,
     val url: String?,
     val method: String?,
     val protocol: String?,

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/details/presentation/utils/DetailsNetworkTrafficTextUtils.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/details/presentation/utils/DetailsNetworkTrafficTextUtils.kt
@@ -47,6 +47,7 @@ internal object DetailsNetworkTrafficTextUtils {
     }
 
     fun toOverviewAnnotatedString(data: KtorOverviewData): AnnotatedString = buildAnnotatedString {
+        onAppendToAnnotatedString("Tags", data.tags)
         onAppendToAnnotatedString("URL", data.url)
         onAppendToAnnotatedString("Method", data.method)
         onAppendToAnnotatedString("Protocol", data.protocol)

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/data/mapper/NetworkTrafficDataLocalMapper.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/data/mapper/NetworkTrafficDataLocalMapper.kt
@@ -10,6 +10,7 @@ import sp.bvantur.inspektify.ktor.core.data.utils.extensions.getMethod
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.getMethodWithPath
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.getPresentationStatusCode
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.getSize
+import sp.bvantur.inspektify.ktor.core.data.utils.extensions.getTags
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.getTime
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.isCompleted
 import sp.bvantur.inspektify.ktor.core.data.utils.extensions.isFromActiveSession
@@ -24,6 +25,7 @@ internal object NetworkTrafficDataLocalMapper {
             statusColor = statusCode.statusColor,
             method = getMethod(),
             methodWithPath = getMethodWithPath(),
+            tags = getTags(),
             host = getHost(),
             hostImage = getHostImage(),
             time = getTime(),

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/domain/model/NetworkTrafficListItem.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/domain/model/NetworkTrafficListItem.kt
@@ -8,6 +8,7 @@ internal data class NetworkTrafficListItem(
     val statusColor: StatusColor,
     val method: String,
     val methodWithPath: String,
+    val tags: List<String>,
     val host: String,
     val hostImage: DrawableResource,
     val time: String,

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/domain/usecase/GetAllNetworkTrafficDataUseCase.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/domain/usecase/GetAllNetworkTrafficDataUseCase.kt
@@ -33,7 +33,13 @@ internal class GetAllNetworkTrafficDataUseCaseImpl : GetAllNetworkTrafficDataUse
                 .filter { it.method.isNotBlank() }
                 .map { it.method }.toSet()
 
-            val suggestions = statusCodes + methods
+            val tags = data
+                .flatMap { it.tags }
+                .distinct()
+                .sorted()
+                .toSet()
+
+            val suggestions = statusCodes + methods + tags
 
             val groupedNetworkTrafficData: Map<String, List<NetworkTrafficListItem>> = data.map { item ->
                 item to item.date

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/presentation/KtorListVewModel.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/presentation/KtorListVewModel.kt
@@ -119,6 +119,7 @@ internal class KtorListVewModel :
                     searchTerms.all { term ->
                         item.statusCode.contains(term, ignoreCase = true) ||
                             item.methodWithPath.contains(term, ignoreCase = true) ||
+                            item.tags.any { tag -> tag.contains(term, ignoreCase = true) } ||
                             item.host.contains(term, ignoreCase = true)
                     }
                 }

--- a/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/ui/KtorListScreen.kt
+++ b/inspektify/src/commonMain/kotlin/sp/bvantur/inspektify/ktor/list/ui/KtorListScreen.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.HourglassBottom
 import androidx.compose.material.icons.outlined.Storage
@@ -29,6 +33,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.painterResource
 import sp.bvantur.inspektify.ktor.core.ui.theme.disabled
 import sp.bvantur.inspektify.ktor.core.ui.utils.ColorUtils
@@ -99,6 +104,7 @@ internal fun NetworkPageContent(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun NetworkTrafficItem(item: NetworkTrafficListItem, modifier: Modifier = Modifier) {
     Box(
@@ -121,6 +127,16 @@ internal fun NetworkTrafficItem(item: NetworkTrafficListItem, modifier: Modifier
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.fillMaxWidth().padding(end = 16.dp)
                 )
+
+                if (item.tags.isNotEmpty()) {
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth().padding(top = 4.dp, end = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        item.tags.forEach { tag -> NetworkTrafficTag(tag) }
+                    }
+                }
 
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(top = 4.dp, end = 16.dp),
@@ -173,6 +189,21 @@ internal fun NetworkTrafficItem(item: NetworkTrafficListItem, modifier: Modifier
             )
         }
     }
+}
+
+@Composable
+internal fun NetworkTrafficTag(tag: String, modifier: Modifier = Modifier) {
+    Text(
+        text = tag,
+        color = MaterialTheme.colorScheme.primary,
+        fontSize = 12.sp,
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    )
 }
 
 @Composable

--- a/inspektify/src/commonMain/sqldelight/migrations/2.sqm
+++ b/inspektify/src/commonMain/sqldelight/migrations/2.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE NetworkTrafficDataLocal ADD COLUMN tags TEXT;

--- a/inspektify/src/commonMain/sqldelight/sp/bvantur/inspektify/InspektifyDB.sq
+++ b/inspektify/src/commonMain/sqldelight/sp/bvantur/inspektify/InspektifyDB.sq
@@ -11,6 +11,7 @@ CREATE TABLE NetworkTrafficDataLocal (
   host TEXT,
   path TEXT,
   protocol TEXT,
+  tags TEXT AS List<String>,
 
   requestTimestamp INTEGER,
   requestHeaders TEXT AS Set<Map.Entry<String, List<String>>>,
@@ -34,8 +35,8 @@ getAllNetworkTraffic:
 SELECT * FROM NetworkTrafficDataLocal;
 
 insertNetworkTraffic:
-INSERT OR REPLACE INTO NetworkTrafficDataLocal(id, sessionId, method, url, host, path, protocol, requestTimestamp, requestHeaders, requestPayload, requestContentType, requestPayloadSize, requestHeadersSize, responseTimestamp, responseStatus, responseStatusDescription, responseHeaders, responsePayload, responseContentType, responsePayloadSize, responseHeadersSize, tookDurationInMs)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO NetworkTrafficDataLocal(id, sessionId, method, url, host, path, protocol, tags, requestTimestamp, requestHeaders, requestPayload, requestContentType, requestPayloadSize, requestHeadersSize, responseTimestamp, responseStatus, responseStatusDescription, responseHeaders, responsePayload, responseContentType, responsePayloadSize, responseHeadersSize, tookDurationInMs)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 getNetworkTrafficById:
 SELECT * FROM NetworkTrafficDataLocal WHERE id = ?;

--- a/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyRequestHandlerTest.kt
+++ b/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/client/data/InspektifyRequestHandlerTest.kt
@@ -1,0 +1,73 @@
+@file:Suppress("ktlint:standard:max-line-length")
+
+package sp.bvantur.inspektify.ktor.client.data
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpMethod
+import io.ktor.http.URLProtocol
+import io.ktor.http.encodedPath
+import kotlinx.coroutines.test.runTest
+import sp.bvantur.inspektify.ktor.PayloadTooLargePolicy
+import sp.bvantur.inspektify.ktor.inspektifyTags
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class InspektifyRequestHandlerTest {
+
+    private lateinit var requestHandler: InspektifyRequestHandler
+
+    @BeforeTest
+    fun setup() {
+        requestHandler = InspektifyRequestHandler()
+    }
+
+    @Test
+    fun `GIVEN a tagged request WHEN handleRequest is called THEN the tags are captured`() = runTest {
+        val request = graphQlRequest().also { it.inspektifyTags("SearchProducts", "query") }
+
+        assertEquals(listOf("SearchProducts", "query"), requestHandler.handleRequest(request).tags)
+    }
+
+    @Test
+    fun `GIVEN an untagged request WHEN handleRequest is called THEN the tags are null`() = runTest {
+        assertNull(requestHandler.handleRequest(graphQlRequest()).tags)
+    }
+
+    @Test
+    fun `GIVEN repeated tagging WHEN handleRequest is called THEN the tags accumulate in order without duplicates`() =
+        runTest {
+            val request = graphQlRequest().also {
+                it.inspektifyTags("api-v2")
+                it.inspektifyTags("SearchProducts", "api-v2")
+            }
+
+            assertEquals(listOf("api-v2", "SearchProducts"), requestHandler.handleRequest(request).tags)
+        }
+
+    @Test
+    fun `GIVEN only blank tags WHEN handleRequest is called THEN the tags are null`() = runTest {
+        val request = graphQlRequest().also { it.inspektifyTags("", "   ") }
+
+        assertNull(requestHandler.handleRequest(request).tags)
+    }
+
+    private fun graphQlRequest(): HttpRequestBuilder = HttpRequestBuilder().also { request ->
+        request.method = HttpMethod.Post
+        request.url {
+            protocol = URLProtocol.HTTPS
+            host = "www.example.com"
+            encodedPath = "/graphql"
+        }
+        request.attributes.put(requestHandler.getNetworkTrafficIdKey(), 1L)
+    }
+
+    private suspend fun InspektifyRequestHandler.handleRequest(request: HttpRequestBuilder) = handleRequest(
+        request = request,
+        sessionId = 1L,
+        redactHeaders = emptyList(),
+        redactBodyProperties = emptyList(),
+        payloadTooLargePolicy = PayloadTooLargePolicy.BodySizeLimit()
+    )
+}

--- a/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataExtensionsKtTest.kt
+++ b/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataExtensionsKtTest.kt
@@ -18,6 +18,7 @@ class NetworkTrafficDataExtensionsKtTest {
             host = "example.com",
             path = "/path",
             protocol = "HTTP/1.1",
+            tags = listOf("SearchProducts", "query"),
             requestTimestamp = 1234567890,
             requestHeaders = setOf(
                 "Header1" to listOf("value1", "value2"),
@@ -52,6 +53,7 @@ class NetworkTrafficDataExtensionsKtTest {
         assertEquals(networkTrafficDataLocal.host, networkTraffic.host)
         assertEquals(networkTrafficDataLocal.path, networkTraffic.path)
         assertEquals(networkTrafficDataLocal.protocol, networkTraffic.protocol)
+        assertEquals(networkTrafficDataLocal.tags, networkTraffic.tags)
         assertEquals(networkTrafficDataLocal.requestTimestamp, networkTraffic.requestTimestamp)
         assertEquals(networkTrafficDataLocal.requestHeaders, networkTraffic.requestHeaders)
         assertEquals(networkTrafficDataLocal.requestPayload, networkTraffic.requestPayload)

--- a/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataLocalExtensionsKtTest.kt
+++ b/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/core/data/utils/extensions/NetworkTrafficDataLocalExtensionsKtTest.kt
@@ -23,6 +23,7 @@ class NetworkTrafficDataLocalExtensionsKtTest {
         host = null,
         path = null,
         protocol = null,
+        tags = null,
         requestTimestamp = null,
         requestHeaders = null,
         requestPayload = null,
@@ -107,6 +108,27 @@ class NetworkTrafficDataLocalExtensionsKtTest {
         val methodWithPath = data.getMethodWithPath()
 
         assertEquals("method path", methodWithPath)
+    }
+
+    @Test
+    fun `GIVEN tags is null WHEN getTags is called THEN returns empty list`() {
+        val data = networkTrafficDataLocal.copy(tags = null)
+
+        assertEquals(emptyList(), data.getTags())
+    }
+
+    @Test
+    fun `GIVEN tags contains blank entries WHEN getTags is called THEN blank entries are dropped`() {
+        val data = networkTrafficDataLocal.copy(tags = listOf("SearchProducts", "   ", "query"))
+
+        assertEquals(listOf("SearchProducts", "query"), data.getTags())
+    }
+
+    @Test
+    fun `GIVEN tags is not null WHEN getTags is called THEN returns actual data`() {
+        val data = networkTrafficDataLocal.copy(tags = listOf("SearchProducts", "query"))
+
+        assertEquals(listOf("SearchProducts", "query"), data.getTags())
     }
 
     @Test

--- a/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/core/di/AppComponents.kt
+++ b/inspektify/src/commonTest/kotlin/sp/bvantur/inspektify/ktor/core/di/AppComponents.kt
@@ -22,6 +22,12 @@ internal object AppComponents {
             override fun encode(value: Set<Map.Entry<String, List<String>>>): String = ""
         }
 
+    private val tagsAdapter = object : ColumnAdapter<List<String>, String> {
+        override fun decode(databaseValue: String): List<String> = emptyList()
+
+        override fun encode(value: List<String>): String = ""
+    }
+
     // Core dependencies - initialized once
     val dispatcherProvider: DispatcherProvider = InspektifyDispatcherProvider()
 
@@ -47,7 +53,8 @@ internal object AppComponents {
             driver = DatabaseDriverProvider.createDriver(),
             NetworkTrafficDataLocalAdapter = NetworkTrafficDataLocal.Adapter(
                 responseHeadersAdapter = listOfNetworkTrafficHeaderAdapter,
-                requestHeadersAdapter = listOfNetworkTrafficHeaderAdapter
+                requestHeadersAdapter = listOfNetworkTrafficHeaderAdapter,
+                tagsAdapter = tagsAdapter
             )
         )
     }

--- a/inspektifySample/composeApp/src/commonMain/kotlin/sp/bvantur/inspektify/sample/data/user/UserRemoteDataSource.kt
+++ b/inspektifySample/composeApp/src/commonMain/kotlin/sp/bvantur/inspektify/sample/data/user/UserRemoteDataSource.kt
@@ -9,6 +9,7 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.contentType
 import io.ktor.http.path
 import kotlinx.coroutines.withContext
+import sp.bvantur.inspektify.ktor.inspektifyTags
 import sp.bvantur.inspektify.sample.data.utils.DispatcherProvider
 import sp.bvantur.inspektify.sample.data.utils.NetworkUtils
 
@@ -16,6 +17,7 @@ class UserRemoteDataSource(private val httpClient: HttpClient, private val dispa
     suspend fun getUser(userId: UserId): Result<UserRemote?> = withContext(dispatcherProvider.io) {
         NetworkUtils.safeApiCall {
             httpClient.request {
+                inspektifyTags("Get user", "users")
                 url {
                     method = HttpMethod.Get
                     path("users/$userId")
@@ -27,6 +29,7 @@ class UserRemoteDataSource(private val httpClient: HttpClient, private val dispa
     suspend fun createUser(user: CreateUserRemote): Result<CreateUserRemote> = withContext(dispatcherProvider.io) {
         NetworkUtils.safeApiCall {
             httpClient.request {
+                inspektifyTags("Create user", "users")
                 url {
                     method = HttpMethod.Post
                     path("users")
@@ -40,6 +43,7 @@ class UserRemoteDataSource(private val httpClient: HttpClient, private val dispa
     suspend fun getAllUsers(): Result<Any> = withContext(dispatcherProvider.io) {
         NetworkUtils.safeApiCall {
             httpClient.request {
+                inspektifyTags("Get all users", "users")
                 url {
                     method = HttpMethod.Get
                     path("users")


### PR DESCRIPTION
The traffic list identifies a request by its URL. That works until an API puts many operations behind one path. GraphQL is the obvious case, where everything is a POST to /graphql, but it also happens with JSON-RPC, batching endpoints, and any API that routes on the body rather than the route. You get a column of identical rows and have to open them one at a time to find the call you're after.

This adds `HttpRequestBuilder.inspektifyTags(vararg String)` so a caller can attach a few short names to a request. What goes in them is up to the app: an operation name, a query/mutation kind, an API version, a feature area, whether the call came from a background job. Repeated calls accumulate, so you can tag broadly in `defaultRequest` and narrow it at the call site. Blank tags are dropped and duplicates collapsed, keeping insertion order.

The implementation follows what's already there. Tags travel as a Ktor attribute, are read in InspektifyRequestHandler, and are stored in a new `tags` column as a JSON array through a ColumnAdapter, the same way request and response headers already work. The column is nullable behind migration 2.sqm, so existing databases carry over untouched.

In the list they render as small chips under the method and path. I kept them secondary on purpose, so a row still reads as its endpoint first and untagged requests look exactly as they do today. Tags are also matched by the search, offered as search suggestions, and shown in the transaction overview and the copied text.

Also included: docs/REQUEST_TAGS.md linked from the README, KDoc on the public function, unit tests covering capture, accumulation and blank handling, and the sample app tagging its three calls so the behaviour is visible when you run it.

Let me know if you'd prefer different naming or a different treatment for the chips.